### PR TITLE
Add authentication with JWT and protect enrollment actions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+PyJWT

--- a/src/app.py
+++ b/src/app.py
@@ -5,14 +5,46 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
+from datetime import datetime, timedelta, timezone
 import os
 from pathlib import Path
 
+import jwt
+from jwt.exceptions import InvalidTokenError
+from fastapi import Depends, FastAPI, Header, HTTPException
+from pydantic import BaseModel
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import RedirectResponse
+
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
+
+SECRET_KEY = os.getenv("SECRET_KEY", "dev-only-secret-change-me-please-set-a-real-secret")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60
+
+
+class RegisterRequest(BaseModel):
+    email: str
+    password: str
+    role: str = "student"
+
+
+class LoginRequest(BaseModel):
+    email: str
+    password: str
+
+
+users = {
+    "teacher@mergington.edu": {
+        "password": "teacher123",
+        "role": "admin"
+    },
+    "student@mergington.edu": {
+        "password": "student123",
+        "role": "student"
+    }
+}
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
@@ -78,9 +110,76 @@ activities = {
 }
 
 
+def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
+    payload = data.copy()
+    expire = datetime.now(timezone.utc) + (
+        expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
+    payload.update({"exp": expire})
+    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def get_current_user(authorization: str | None = Header(default=None)) -> dict:
+    if not authorization:
+        raise HTTPException(
+            status_code=401,
+            detail="Missing Authorization header"
+        )
+
+    parts = authorization.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid Authorization header format"
+        )
+
+    token = parts[1]
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except InvalidTokenError:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+
+    email = payload.get("sub")
+    role = payload.get("role")
+    if not email or email not in users:
+        raise HTTPException(status_code=401, detail="Invalid token subject")
+
+    return {"email": email, "role": role}
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
+
+
+@app.post("/auth/register")
+def register_user(request: RegisterRequest):
+    if request.email in users:
+        raise HTTPException(status_code=400, detail="Email already registered")
+
+    if request.role not in {"student", "admin"}:
+        raise HTTPException(status_code=400, detail="Role must be student or admin")
+
+    users[request.email] = {
+        "password": request.password,
+        "role": request.role
+    }
+    return {"message": "User registered", "email": request.email, "role": request.role}
+
+
+@app.post("/auth/login")
+def login_user(request: LoginRequest):
+    user = users.get(request.email)
+    if not user or user["password"] != request.password:
+        raise HTTPException(status_code=401, detail="Invalid email or password")
+
+    access_token = create_access_token({"sub": request.email, "role": user["role"]})
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@app.get("/auth/me")
+def auth_me(current_user: dict = Depends(get_current_user)):
+    return current_user
 
 
 @app.get("/activities")
@@ -89,8 +188,14 @@ def get_activities():
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, current_user: dict = Depends(get_current_user)):
     """Sign up a student for an activity"""
+    if current_user["role"] != "admin" and current_user["email"] != email:
+        raise HTTPException(
+            status_code=403,
+            detail="Students can only sign up themselves"
+        )
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +216,14 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, current_user: dict = Depends(get_current_user)):
     """Unregister a student from an activity"""
+    if current_user["role"] != "admin" and current_user["email"] != email:
+        raise HTTPException(
+            status_code=403,
+            detail="Students can only unregister themselves"
+        )
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")


### PR DESCRIPTION
## Summary
- add register/login endpoints for authenticated users
- add JWT bearer token validation middleware
- protect signup/unregister endpoints with authentication and authorization checks

## Validation
- unauthenticated signup returns 401
- student login returns 200 and token
- student cannot sign up other users (403)
- admin can sign up other users (200)